### PR TITLE
Fix ControlParameters FaceID type; NFD expects 105, not 132

### DIFF
--- a/src/net/named_data/jndn/encoding/Tlv0_1WireFormat.java
+++ b/src/net/named_data/jndn/encoding/Tlv0_1WireFormat.java
@@ -309,7 +309,7 @@ public class Tlv0_1WireFormat extends WireFormat {
     // TODO: Encode Uri.
 
     encoder.writeOptionalNonNegativeIntegerTlv
-      (Tlv.FaceID, controlParameters.getFaceId());
+      (Tlv.ControlParameters_FaceId, controlParameters.getFaceId());
     encodeName(controlParameters.getName(), new int[1], new int[1], encoder);
 
     encoder.writeTypeAndLength


### PR DESCRIPTION
Found this bug while debugging why jndn would not register routes correctly on a NFD (e.g. /nfd/localhost/rib/register). There was a difference between the ControlParameters sent from `nfdc` and from the jndn library (disregard different Names):

`nfdc register`: h%1D%07%0E%08%05hello%08%05world **i** %02%01%00o%01%FFj%01%00l%01%01
jndn ControlParameters: h%1A%07%0E%08%04test%08%06route2 **%84** %02%01%00o%01%FFl%01%03

This commit should fix the incorrect TLV type value above.
