### PR TITLE
Node: fixes a bug where NFD registration commands did not have the passed in ForwardingFlags

### DIFF
--- a/src/net/named_data/jndn/Node.java
+++ b/src/net/named_data/jndn/Node.java
@@ -1258,6 +1258,7 @@ public class Node implements ElementListener {
 
     ControlParameters controlParameters = new ControlParameters();
     controlParameters.setName(prefix);
+    controlParameters.setForwardingFlags(flags);
 
     Interest commandInterest = new Interest();
 


### PR DESCRIPTION
Before this change, the NFD would register prefixes incorrectly (see bug report at http://redmine.named-data.net/issues/2870); the bug is now identified to be ForwardingFlags that are not attached to the ControlParameters request sent to the NFD. In my tests, the NFD now registers the routes correctly.