### PR TITLE
added wait for reconnect with timeout logic in send() call

### DIFF
--- a/examples/src/net/named_data/jndn/tests/TestAsyncTcpTransport.java
+++ b/examples/src/net/named_data/jndn/tests/TestAsyncTcpTransport.java
@@ -1,0 +1,328 @@
+/**
+ * Copyright (C) 2015-2016 Intel Corporation.
+ *
+ * @author: Andrew Brown <andrew.brown@intel.com>
+ * @author: Wei Yu <w.yu@intel.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * A copy of the GNU Lesser General Public License is in the file COPYING.
+ */
+package net.named_data.jndn.tests;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+
+import net.named_data.jndn.transport.AsyncTcpTransport;
+
+public class TestAsyncTcpTransport {
+  private static final Logger LOGGER = Logger.getLogger(TestAsyncTcpTransport.class.getName());
+  private static final int PORT = 3098;
+  private static int count = 0;
+  private static ServerSocket server = null;
+
+  /**
+   * Test that reconnection logic does not break normal operation, i.e. make sure we didn't break the happy path
+   */
+  @Test
+  public void testHappyPath() {
+    // start the mock nfd first
+    startMockNfd(PORT);
+
+    // reset the count
+    count = 0;
+
+    // create pool for tcp transport
+    ScheduledExecutorService pool = Executors.newScheduledThreadPool(3);
+
+    // create and start tcp transport
+    AsyncTcpTransport transport = createAndStartClient(pool);
+
+    // start sending pings
+    ScheduledExecutorService pool2 = Executors.newSingleThreadScheduledExecutor();
+    send(pool2, transport, "ping");
+
+    // allow enough time to receive some ping
+    for (int i = 0; i < 10; i++) {
+      sleep(1000);
+      if (count > 0) {
+        break;
+      }
+    }
+
+    // stop server
+    stopMockNfd(transport);
+
+    // shutdown the pools
+    shutdownPool(pool);
+    shutdownPool(pool2);
+
+    // make sure we received some pings
+    assertTrue(count > 0);
+  }
+
+
+  /**
+   * Test to mimic when the NFD is not up initially (but then starts) and the transport attempts to open and send data
+   */
+  @Test
+  public void testWithoutServerInitiallyOn() {
+    // create the pool
+    ScheduledExecutorService pool = Executors.newScheduledThreadPool(3);
+
+    // create and start the transport
+    AsyncTcpTransport transport = createAndStartClient(pool);
+
+    // start sending pings
+    ScheduledExecutorService pool2 = Executors.newSingleThreadScheduledExecutor();
+    send(pool2, transport, "ping1");
+
+    // now start the mock nfd
+    startMockNfd(PORT);
+
+    // reset count so we know if count > 0 the transport reconnects successfully
+    count = 0;
+
+    // allow reconnect enough time to complete
+    for (int i = 0; i < 10; i++) {
+      sleep(1000);
+      if (count > 0) {
+        break;
+      }
+    }
+
+    // stop server
+    stopMockNfd(transport);
+
+    // shutdown the pools
+    shutdownPool(pool);
+    shutdownPool(pool2);
+
+    // we have received some pings
+    assertTrue(count > 0);
+  }
+
+  /**
+   * This tests a client constantly sending data and the reboot of mock NFD which triggers the reconnect
+   */
+  @Test
+  public void testWithServerRebootWhileSending() {
+    // start the mock nfd
+    startMockNfd(PORT);
+
+    // create the pool for transport
+    ScheduledExecutorService pool = Executors.newScheduledThreadPool(3);
+
+    // create and start the transport
+    AsyncTcpTransport transport = createAndStartClient(pool);
+
+    // start sending pings
+    ScheduledExecutorService pool2 = Executors.newSingleThreadScheduledExecutor();
+    send(pool2, transport, "ping2");
+
+    // reboot the mock nfd by closing the current channel
+    stopMockNfd(transport);
+
+    // reset the count so if it is > 0 we know the reconnect is success
+    count = 0;
+
+    // allow reconnect enough time to complete
+    for (int i = 0; i < 10; i++) {
+      sleep(1000);
+      if (count > 0) {
+        break;
+      }
+    }
+
+    // shutdown the server
+    stopMockNfd(transport);
+
+    // cleanup pools
+    shutdownPool(pool);
+    shutdownPool(pool2);
+
+    // make sure we received some pings
+    assertTrue(count > 0);
+  }
+
+  /**
+   * this is to test reboot the nfd while client is not sending any data and client will reconnect after the next few
+   * send request
+   */
+  @Test
+  public void testWithServerRebootWhileIdling() {
+    // start the mock nfd
+    startMockNfd(PORT);
+
+    // create the pool for transport
+    ScheduledExecutorService pool = Executors.newScheduledThreadPool(3);
+
+    // create and start the transport
+    AsyncTcpTransport transport = createAndStartClient(pool);
+
+    // start sending pings
+    ScheduledExecutorService pool2 = Executors.newSingleThreadScheduledExecutor();
+    send(pool2, transport, "ping3");
+
+    // shutdown the send data pool
+    shutdownPool(pool2);
+
+    // close current channel of the mock nfd
+    stopMockNfd(transport);
+
+    // reset the count
+    count = 0;
+
+    // start sending again
+    ScheduledExecutorService pool3 = Executors.newSingleThreadScheduledExecutor();
+    send(pool3, transport, "ping4");
+
+    // wait long enough for client to reconnect and send some pings
+    for (int i = 0; i < 10; i++) {
+      sleep(1000);
+      if (count > 0) {
+        break;
+      }
+    }
+
+    // stop server
+    stopMockNfd(transport);
+
+    // shutdown the pools
+    shutdownPool(pool);
+    shutdownPool(pool3);
+
+    // we should see something from client after reconnect
+    assertTrue(count > 0);
+  }
+
+  private AsyncTcpTransport createAndStartClient(ScheduledExecutorService pool) {
+    AsyncTcpTransport transport = new AsyncTcpTransport(pool);
+
+    AsyncTcpTransport.ConnectionInfo cinfo = new AsyncTcpTransport.ConnectionInfo("localhost", PORT, false);
+    try {
+      transport.connect(cinfo, null, null);
+    } catch (IOException e) {
+      LOGGER.log(Level.WARNING, null, e);
+    }
+    return transport;
+  }
+
+  private void shutdownPool(ScheduledExecutorService pool) {
+    pool.shutdown();
+    try {
+      pool.awaitTermination(10, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      LOGGER.log(Level.WARNING, null, e);
+    }
+  }
+
+  private void send(final ScheduledExecutorService pool, final AsyncTcpTransport transport, final String ping) {
+    pool.schedule(new Runnable() {
+      public void run() {
+        try {
+          transport.send(ByteBuffer.wrap((ping + "\n").getBytes()));
+        } catch (IOException e) {
+          LOGGER.log(Level.WARNING, null, e);
+        }
+        send(pool, transport, ping);
+      }
+    }, 1, TimeUnit.SECONDS);
+  }
+
+  private void sleep(long ms) {
+    try {
+      Thread.sleep(ms);
+    } catch (InterruptedException e) {
+      LOGGER.log(Level.WARNING, null, e);
+    }
+  }
+
+  private void stopMockNfd(AsyncTcpTransport transport) {
+    try {
+      transport.send(ByteBuffer.wrap("close\n".getBytes()));
+    } catch (IOException e) {
+      LOGGER.log(Level.WARNING, null, e);
+    }
+    sleep(3000);
+  }
+
+  private void startMockNfd(final int port) {
+    if (server == null) {
+      new Thread(new Runnable() {
+        public void run() {
+          try {
+            server = new ServerSocket(port);
+            while (true) {
+              LOGGER.log(Level.INFO, "before accept new connection");
+              new MockNfdChannel(server.accept());
+              sleep(1000);
+            }
+          } catch (IOException e) {
+            LOGGER.log(Level.WARNING, null, e);
+          }
+        }
+      }).start();
+    }
+  }
+
+  private class MockNfdChannel extends Thread {
+    private final Socket client_;
+
+    MockNfdChannel(Socket client) {
+      this.client_ = client;
+      start();
+    }
+
+    public void run() {
+      try {
+        LineNumberReader reader = new LineNumberReader(new InputStreamReader(client_.getInputStream()));
+        String line;
+
+        while ((line = reader.readLine()) != null) {
+          if ("close".equals(line)) {
+            LOGGER.log(Level.INFO, "exit received");
+            break;
+          } else {
+            LOGGER.log(Level.INFO, "received:" + line);
+            count++;
+          }
+        }
+        reader.close();
+      } catch (IOException e) {
+        LOGGER.log(Level.WARNING, null, e);
+      } finally {
+        if (client_ != null) {
+          try {
+            client_.close();
+          } catch (IOException e) {
+            LOGGER.log(Level.WARNING, null, e);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/net/named_data/jndn/transport/AsyncTcpTransport.java
+++ b/src/net/named_data/jndn/transport/AsyncTcpTransport.java
@@ -1,6 +1,9 @@
 /**
  * Copyright (C) 2015-2016 Regents of the University of California.
+ *
  * @author: Jeff Thompson <jefft0@remap.ucla.edu>
+ * @author: Andrew Brown <andrew.brown@intel.com>
+ * @author: Wei Yu <w.yu@intel.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -39,10 +42,32 @@ import net.named_data.jndn.util.Common;
  * AsyncTcpTransport extends Transport for async communication over TCP by
  * dispatching reads from an AsynchronousSocketChannel to a
  * ScheduledExecutorService.
+ * There is reconnection logic implemented if any one of the following case happens:
+ * 1. read completion handler fails
+ * 2. write completion handler fails
+ * 3. connect fails
+ *
+ * reconnect is scheduled with a 5 sec delay on the same thread pool passed in the constructor, there
+ * will be only at most one reconnect task scheduled, the read completion handler will only trigger at most
+ * one reconnect, same to the write completion handler. The subsequent reconnect is triggered only by the previous
+ * reconnect failure only. Reconnect will be scheduled and executed until nfd is back up.
+ * While it is reconnecting or waiting to be reconnected the send() call will either block or non-block based on the
+ * flag in the connectionInfo object.
+ * While reconnect will solve the connection issue after it succeeded, but will not re-register prefixes. This should
+ * be handled appropriately by client logic.
+ *
+ * To test this reconnect:
+ * 1. launch nfd
+ * 2. launch client using this transport
+ * 3. wait prefix registered and some interests expressed successfully from client
+ * 4. stop nfd
+ * 5. client will catch IOException (broken pipe, connection refused, etc) when it tries to express interests
+ * 6. start nfd again
+ * 7. client will be able to express interests again normally
  */
-public class AsyncTcpTransport extends Transport {
-  public AsyncTcpTransport(ScheduledExecutorService threadPool)
-  {
+public class AsyncTcpTransport extends Transport
+{
+  public AsyncTcpTransport(ScheduledExecutorService threadPool) {
     threadPool_ = threadPool;
 
     // This is the CompletionHandler for asyncRead().
@@ -55,7 +80,7 @@ public class AsyncTcpTransport extends Transport {
             elementReader_.onReceivedData(inputBuffer_);
           }
 
-          // Repeatedly do  async read.
+          // Repeatedly do async read.
           asyncRead();
         } catch (Throwable ex) {
           logger_.log(Level.SEVERE, null, ex);
@@ -63,8 +88,10 @@ public class AsyncTcpTransport extends Transport {
       }
 
       public void failed(Throwable ex, Void attachment) {
-        logger_.log(Level.SEVERE, null, ex);
-      }};
+        logger_.log(Level.SEVERE, "Failed to read from transport", ex);
+        tryToScheduleReconnect();
+      }
+    };
 
     // This is the CompletionHandler for send().
     writeCompletionHandler_ = new CompletionHandler<Integer, ByteBuffer>() {
@@ -73,8 +100,7 @@ public class AsyncTcpTransport extends Transport {
         try {
           if (data.hasRemaining()) {
             channel_.write(data, data, writeCompletionHandler_);
-          }
-          else {
+          } else {
             writeLock_.release();
           }
         } catch (Throwable ex) {
@@ -83,9 +109,11 @@ public class AsyncTcpTransport extends Transport {
       }
 
       public void failed(Throwable ex, ByteBuffer data) {
+        logger_.log(Level.SEVERE, "Failed to write to transport", ex);
         writeLock_.release();
-        logger_.log(Level.SEVERE, null, ex);
-      }};
+        tryToScheduleReconnect();
+      }
+    };
   }
 
   /**
@@ -97,23 +125,29 @@ public class AsyncTcpTransport extends Transport {
      * Create a ConnectionInfo with the given host and port.
      * @param host The host for the connection.
      * @param port The port number for the connection.
+     * @param blockForReconnect if true, then block on send until a dropped connection is reconnected within DEFAULT_LOCK_TIMEOUT_MS
      */
-    public
-    ConnectionInfo(String host, int port)
-    {
+    public ConnectionInfo(String host, int port, boolean blockForReconnect) {
       host_ = host;
       port_ = port;
+      blockForReconnect_ = blockForReconnect;
     }
 
     /**
-     * Create a ConnectionInfo with the given host and default port 6363.
+     * Create a ConnectionInfo with the given host and port. blockForReconnect default to false
+     * @param host The host for the connection.
+     * @param port The port number for the connection.
+     */
+    public ConnectionInfo(String host, int port) {
+      this(host, port, false);
+    }
+
+    /**
+     * Create a ConnectionInfo with the given host and default port 6363 with default not to blockForReconnect
      * @param host The host for the connection.
      */
-    public
-    ConnectionInfo(String host)
-    {
-      host_ = host;
-      port_ = 6363;
+    public ConnectionInfo(String host) {
+      this(host, 6363, false);
     }
 
     /**
@@ -121,17 +155,31 @@ public class AsyncTcpTransport extends Transport {
      * @return The host.
      */
     public final String
-    getHost() { return host_; }
+    getHost() {
+      return host_;
+    }
 
     /**
      * Get the port given to the constructor.
      * @return The port number.
      */
     public final int
-    getPort() { return port_; }
+    getPort() {
+      return port_;
+    }
+
+    /**
+     * Get blockForReconnect
+     * @return true if blockForReconnect
+     */
+    public final boolean
+    isBlockForReconnect() {
+      return blockForReconnect_;
+    }
 
     private final String host_;
     private final int port_;
+    private final boolean blockForReconnect_;
   }
 
   /**
@@ -148,15 +196,13 @@ public class AsyncTcpTransport extends Transport {
    * @throws java.io.IOException
    */
   public boolean
-  isLocal(Transport.ConnectionInfo connectionInfo) throws IOException
-  {
-    synchronized(isLocalLock_) {
-      if(connectionInfo_ == null || !((ConnectionInfo)connectionInfo).getHost()
-        .equals(connectionInfo_.getHost()))
-      {
+  isLocal(Transport.ConnectionInfo connectionInfo) throws IOException {
+    synchronized (isLocalLock_) {
+      if (connectionInfo_ == null || !((ConnectionInfo) connectionInfo).getHost()
+          .equals(connectionInfo_.getHost())) {
         isLocal_ = TcpTransport.getIsLocal
-          (((ConnectionInfo)connectionInfo).getHost());
-        connectionInfo_ = (ConnectionInfo)connectionInfo;
+            (((ConnectionInfo) connectionInfo).getHost());
+        connectionInfo_ = (ConnectionInfo) connectionInfo;
       }
 
       return isLocal_;
@@ -168,7 +214,9 @@ public class AsyncTcpTransport extends Transport {
    * @return True.
    */
   public boolean
-  isAsync() { return true; }
+  isAsync() {
+    return true;
+  }
 
   /**
    * Connect according to the info in ConnectionInfo, and use elementListener.
@@ -181,42 +229,114 @@ public class AsyncTcpTransport extends Transport {
    */
   public void
   connect
-    (Transport.ConnectionInfo connectionInfo, ElementListener elementListener,
-     final Runnable onConnected)
-    throws IOException
-  {
+  (Transport.ConnectionInfo connectionInfo, ElementListener elementListener,
+   final Runnable onConnected)
+      throws IOException {
+    logger_.log(Level.FINE, "Connecting...");
     // TODO: Close a previous connection.
 
-    channel_ = AsynchronousSocketChannel.open
-      (AsynchronousChannelGroup.withThreadPool(threadPool_));
+    channelGroup_ = AsynchronousChannelGroup.withThreadPool(threadPool_);
+
+    channel_ = AsynchronousSocketChannel.open(channelGroup_);
+
+    //store other info for reconnect
+    this.connectionInfoForReconnect_ = (ConnectionInfo) connectionInfo;
+    this.elementListener_ = elementListener;
+    this.onConnected_ = onConnected;
+
     // connect is already async, so no need to dispatch.
     channel_.connect
-      (new InetSocketAddress
-         (((ConnectionInfo)connectionInfo).getHost(),
-          ((ConnectionInfo)connectionInfo).getPort()),
-       null,
-       new CompletionHandler<Void, Void>() {
-         public void completed(Void dummy, Void attachment) {
-           // Need to catch and log exceptions at this async entry point.
-           try {
-             if (onConnected != null)
-               onConnected.run();
-             asyncRead();
-           } catch (Throwable ex) {
-             logger_.log(Level.SEVERE, null, ex);
-           }
-         }
+        (new InetSocketAddress
+                (((ConnectionInfo) connectionInfo).getHost(),
+                    ((ConnectionInfo) connectionInfo).getPort()),
+            null,
+            new CompletionHandler<Void, Void>() {
+              public void completed(Void dummy, Void attachment) {
+                logger_.log(Level.FINE, "Connected");
+                // Need to catch and log exceptions at this async entry point.
+                try {
+                  if (onConnected != null)
+                    onConnected.run();
+                  asyncRead();
+                } catch (Throwable ex) {
+                  logger_.log(Level.SEVERE, null, ex);
+                }
+              }
 
-         public void failed(Throwable ex, Void attachment) {
-           logger_.log(Level.SEVERE, null, ex);
-         }});
+              public void failed(Throwable ex, Void attachment) {
+                logger_.log(Level.SEVERE, "Failed to connect", ex);
+                tryToScheduleReconnect();
+              }
+            });
 
     elementReader_ = new ElementReader(elementListener);
   }
 
   private void
-  asyncRead()
-  {
+  reconnect() throws IOException {
+    logger_.log(Level.FINE, "Reconnecting...");
+    channel_ = AsynchronousSocketChannel.open(channelGroup_);
+
+    // connect is already async, so no need to dispatch.
+    channel_.connect
+        (new InetSocketAddress
+                (connectionInfoForReconnect_.getHost(),
+                    connectionInfoForReconnect_.getPort()),
+            null,
+            new CompletionHandler<Void, Void>() {
+              public void completed(Void dummy, Void attachment) {
+                // Need to catch and log exceptions at this async entry point.
+                reconnectLock_.release();
+                try {
+                  if (onConnected_ != null)
+                    onConnected_.run();
+                  asyncRead();
+                } catch (Throwable ex) {
+                  logger_.log(Level.SEVERE, null, ex);
+                }
+              }
+
+              public void failed(Throwable ex, Void attachment) {
+                logger_.log(Level.SEVERE, null, ex);
+                scheduleReconnect();
+              }
+            });
+
+    elementReader_ = new ElementReader(elementListener_);
+  }
+
+  /**
+   * This is called from initial connect failure, read failure or write failure
+   * The semaphore will guarantee there is only one such reconnect scheduled at a time
+   */
+  private void tryToScheduleReconnect() {
+    try {
+      if (reconnectLock_.tryAcquire(0, TimeUnit.MICROSECONDS)) {
+        scheduleReconnect();
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * This schedule only comes from reconnect() failure since we yet to release the reconnectLock_
+   */
+  private void scheduleReconnect() {
+    logger_.log(Level.INFO, "Scheduled to reconnect in " + DEFAULT_RECONNECT_TRY_DELAY_MS + "ms");
+    threadPool_.schedule(new Runnable() {
+      public void run() {
+        try {
+          reconnect();
+        } catch (IOException e) {
+          logger_.log(Level.WARNING, null, e);
+        }
+      }
+    }, DEFAULT_RECONNECT_TRY_DELAY_MS, TimeUnit.MILLISECONDS);
+  }
+
+  private void
+  asyncRead() {
     inputBuffer_.limit(inputBuffer_.capacity());
     inputBuffer_.position(0);
     // We only call asyncRead after a previous call, so no need to dispatch.
@@ -230,11 +350,20 @@ public class AsyncTcpTransport extends Transport {
    * @throws IOException For I/O error.
    */
   public void
-  send(ByteBuffer data) throws IOException
-  {
+  send(ByteBuffer data) throws IOException {
+    if (connectionInfoForReconnect_.isBlockForReconnect()) {
+      try {
+        if (writeLock_.tryAcquire(DEFAULT_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS) == false) {
+          throw new IOException("Failed to acquire lock on channel to write buffer");
+        }
+      } catch (InterruptedException e) {
+        throw new IOException(e);
+      }
+    }
+
     if (!getIsConnected())
       throw new IOException
-        ("Cannot send because the socket is not open.  Use connect.");
+          ("Cannot send because the socket is not open.  Use connect.");
 
     // This does not copy the bytes, but only duplicates the position which is
     // updated by write(). We assume that the sender won't change the bytes of
@@ -260,20 +389,20 @@ public class AsyncTcpTransport extends Transport {
    * @throws IOException if the channel write fails
    */
   private void sendDataSequentially(ByteBuffer data) throws InterruptedException, IOException {
-    if(writeLock_.tryAcquire(DEFAULT_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-      channel_.write(data, data, writeCompletionHandler_);
+    if (!connectionInfoForReconnect_.isBlockForReconnect()) {
+      if (writeLock_.tryAcquire(DEFAULT_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS) == false) {
+        throw new IOException("Failed to acquire lock on channel to write buffer");
+      }
     }
-    else{
-      throw new IOException("Failed to acquire lock on channel to write buffer");
-    }
+
+    channel_.write(data, data, writeCompletionHandler_);
   }
 
   /**
    * Do nothing since AsynchronousSocketChannel checks for incoming data.
    */
   public void
-  processEvents() throws IOException, EncodingException
-  {
+  processEvents() throws IOException, EncodingException {
   }
 
   /**
@@ -281,11 +410,9 @@ public class AsyncTcpTransport extends Transport {
    * @return True if connected.
    */
   public boolean
-  getIsConnected() throws IOException
-  {
+  getIsConnected() throws IOException {
     if (channel_ == null)
       return false;
-
     return channel_.getRemoteAddress() != null;
   }
 
@@ -300,6 +427,12 @@ public class AsyncTcpTransport extends Transport {
   private final Object isLocalLock_ = new Object();
   private final Semaphore writeLock_ = new Semaphore(1);
   private static final Logger logger_ = Logger.getLogger
-    (AsyncTcpTransport.class.getName());
+      (AsyncTcpTransport.class.getName());
   public static final int DEFAULT_LOCK_TIMEOUT_MS = 10000;
+  public static final int DEFAULT_RECONNECT_TRY_DELAY_MS = 5000;
+  private AsynchronousChannelGroup channelGroup_;
+  private AsyncTcpTransport.ConnectionInfo connectionInfoForReconnect_;
+  private ElementListener elementListener_;
+  private Runnable onConnected_;
+  private final Semaphore reconnectLock_ = new Semaphore(1);
 }


### PR DESCRIPTION
@jefft0 @andrewsbrown 
Latest for isBlockForReconnect flag implementeation:
Added another lock to wait for reconnect inside send() with timeout of 10ms by default. So now if the flag isBlockForReconnect in connectioninfo is set and if reconnect is outstanding then the send thread will wait on the new lock (waitForReconnectLock_ object). After reconnect is successful it will wake up all the waiting send threads. The timeout duration will be reduced if we got spurious wakeup during the wait. Timeout is handled just like timeout on the writelock_ (IOException), so is InterruptedException.
One thing I'm not sure is if the send has to wait both for reconnect and in sequential send the total timeout period could be longer than 10ms. I can argue both ways but If it is desired to keep the total timeout within 10ms I can pass the remaining allowance to the sendSequentially() to force it wait shorter if send already waited on reconnect for a while.    