### PR TITLE
shutdown the pool now to avoid delayed shutdownchannelgroupexception

### DIFF
--- a/examples/src/net/named_data/jndn/tests/TestAsyncTcpTransport.java
+++ b/examples/src/net/named_data/jndn/tests/TestAsyncTcpTransport.java
@@ -232,12 +232,7 @@ public class TestAsyncTcpTransport {
   }
 
   private void shutdownPool(ScheduledExecutorService pool) {
-    pool.shutdown();
-    try {
-      pool.awaitTermination(10, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
-      LOGGER.log(Level.WARNING, null, e);
-    }
+    pool.shutdownNow();
   }
 
   private void send(final ScheduledExecutorService pool, final AsyncTcpTransport transport, final String ping) {


### PR DESCRIPTION
This is to fix the mvn -q test -DclassName=TestAsyncTcpTransport run failure with ShutdownChannelGroupException at the end 