### PR TITLE
This needs to be thread safe.  Otherwise, this can cause issues (getD…

### DIFF
--- a/src/net/named_data/jndn/encoding/WireFormat.java
+++ b/src/net/named_data/jndn/encoding/WireFormat.java
@@ -722,14 +722,16 @@ public class WireFormat {
   public static WireFormat
   getDefaultWireFormat()
   {
-    if (!defaultWireFormatIsInitialized_) {
-      defaultWireFormatIsInitialized_ = true;
-      defaultWireFormat_ = TlvWireFormat.get();
+  	WireFormat r;
+  	if ((r = defaultWireFormat_) == null) {
+  		synchronized (WireFormat.class) {
+  			if ((r = defaultWireFormat_) == null) {
+  				r = defaultWireFormat_ = TlvWireFormat.get();
+		    }
+	    }
     }
-
-    return defaultWireFormat_;
+    return r;
   }
 
-  private static boolean defaultWireFormatIsInitialized_ = false;
-  private static WireFormat defaultWireFormat_;
+  private static volatile WireFormat defaultWireFormat_;
 }


### PR DESCRIPTION
…efaultWireFormat() can return null).  This is difficult to reproduce but if you have multiple faces and a thread operating on each face it can happen.