### PR TITLE
fix: registerPrefix error

### DIFF
--- a/src/net/named_data/jndn/Node.java
+++ b/src/net/named_data/jndn/Node.java
@@ -868,13 +868,12 @@ public class Node implements ElementListener {
       return;
     }
 
+    commandInterest.setName(new Name("/localhost/nfd/rib/register"));
     if (faceIsLocal) {
-      commandInterest.setName(new Name("/localhost/nfd/rib/register"));
       // The interest is answered by the local host, so set a short timeout.
       commandInterest.setInterestLifetimeMilliseconds(2000.0);
     }
     else {
-      commandInterest.setName(new Name("/localhop/nfd/rib/register"));
       // The host is remote, so set a longer timeout.
       commandInterest.setInterestLifetimeMilliseconds(4000.0);
     }


### PR DESCRIPTION
In the latest version of NFD, to register a prefix, the command interest's prefix is “/localhost/nfd/rib/register” whether it's local or non-local